### PR TITLE
feat: add DownloadReportCard component to CompetitorsLandscapeDemo

### DIFF
--- a/src/components/CompetitorsLandscapeDemo.tsx
+++ b/src/components/CompetitorsLandscapeDemo.tsx
@@ -3,6 +3,7 @@ import CompetitorsCard from "./CompetitorsCard";
 import CustomerSegmentsCard, {
   CustomerSegmentData,
 } from "./CustomerSegmentsCard";
+import DownloadReportCard from "./DownloadReportCard";
 import HeroBanner from "./HeroBanner";
 
 const CompetitorsLandscapeDemo: React.FC = () => {
@@ -92,7 +93,12 @@ const CompetitorsLandscapeDemo: React.FC = () => {
       {/* border */}
       <div className="w-[660px] lg:w-[1152px] h-[1px] opacity-20 border-gradient" />
 
-      <div className="w-full max-w-7xl mx-auto px-4 md:px-6 lg:mx-0 flex flex-col md:flex-row justify-center items-center md:items-start mt-[60.27px] gap-[25px]">
+      {/* Add OpportunityGapsCard */}
+      <div className="mt-[60.27px] mb-[25px]">
+        <DownloadReportCard />
+      </div>
+
+      <div className="w-full max-w-7xl mx-auto px-4 md:px-6 lg:mx-0 flex flex-col md:flex-row justify-center items-center md:items-start gap-[25px]">
         <CompetitorsCard competitors={sampleCompetitors} />
         <CustomerSegmentsCard segments={sampleCustomerSegments} />
       </div>

--- a/src/components/DownloadReportCard.tsx
+++ b/src/components/DownloadReportCard.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+const DownloadReportCard: React.FC = () => {
+  return (
+    <div
+      className="bg-[#151517] backdrop-blur-sm border border-white/20 rounded-xl flex items-center justify-between px-8 py-6"
+      style={{
+        width: "1148px",
+        height: "108px",
+        borderRadius: "12px",
+        borderWidth: "1px",
+      }}
+    >
+      <div className="flex items-center">
+        <h2 className="text-white text-2xl font-semibold">
+          Identified Opportunity Gaps
+        </h2>
+      </div>
+
+      <button className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-lg flex items-center gap-2 transition-colors">
+        <span>Download Comprehensive report</span>
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="text-white"
+        >
+          <path d="M12 15L7 10H17L12 15Z" fill="currentColor" />
+          <path
+            d="M12 4V14M12 14L16 10M12 14L8 10"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M4 17V19C4 20.1046 4.89543 21 6 21H18C19.1046 21 20 20.1046 20 19V17"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default DownloadReportCard;


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add the `DownloadReportCard` component to the `CompetitorsLandscapeDemo` page.

### Why are these changes being made?

These changes introduce a new feature that displays identified opportunity gaps and provides users with a button to download a comprehensive report. This enhancement aims to offer a value-added feature to users by allowing them to obtain detailed insights directly from the interface.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

---
## EntelligenceAI PR Summary 
 Introduced a new DownloadReportCard component and integrated it into the CompetitorsLandscapeDemo page.
- Added DownloadReportCard (presentational, no logic) in src/components/DownloadReportCard.tsx
- Rendered DownloadReportCard above main content in src/components/CompetitorsLandscapeDemo.tsx
- Minor layout adjustments to accommodate the new card 

